### PR TITLE
updates for Metab4_Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Ubuntu Version 14
-FROM ubuntu:14.04
+# Use Ubuntu Version 16
+FROM ubuntu:16.04
 
 MAINTAINER Xia Lab "jasmine.chong@mail.mcgill.ca"
 
@@ -11,13 +11,13 @@ USER root
 # graphviz libraries for RGraphviz), then purge apt-get lists
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common 
+    apt-get install -y software-properties-common sudo 
     
 RUN apt-get update && \
     add-apt-repository ppa:webupd8team/java && \
     apt-get update && \
     echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \ 
-    echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list && \
+    echo "deb http://cran.rstudio.com/bin/linux/ubuntu xenial/" >> /etc/apt/sources.list && \
     gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9 && \
     gpg -a --export E084DAB9 | sudo apt-key add - && \
     apt-get update && \
@@ -45,7 +45,7 @@ RUN apt-get update && \
 
 # Install all R packages from bioconductor 
 
-RUN R -e 'source("http://bioconductor.org/biocLite.R"); biocLite(c("Rserve", "RColorBrewer", "xtable", "fitdistrplus","som", "ROCR", "RJSONIO", "gplots", "e1071", "caTools", "igraph", "randomForest", "Cairo", "pls", "pheatmap", "lattice", "rmarkdown", "knitr", "data.table", "pROC", "Rcpp", "caret", "ellipse", "scatterplot3d", "impute", "pcaMethods", "siggenes", "globaltest", "GlobalAncova", "Rgraphviz", "KEGGgraph", "preprocessCore", "genefilter", "SSPA", "sva", "limma", "pacman"))'
+RUN R -e 'source("http://bioconductor.org/biocLite.R"); biocLite(c("Rserve", "RColorBrewer", "xtable", "fitdistrplus","som", "ROCR", "RJSONIO", "gplots", "e1071", "caTools", "igraph", "randomForest", "Cairo", "pls", "pheatmap", "lattice", "rmarkdown", "knitr", "data.table", "pROC", "Rcpp", "caret", "ellipse", "scatterplot3d", "impute", "pcaMethods", "siggenes", "globaltest", "GlobalAncova", "Rgraphviz", "KEGGgraph", "preprocessCore", "genefilter", "SSPA", "sva", "limma", "pacman", "xcms"))'
 
 ADD rserve.conf /rserve.conf
 ADD metab4script.R /metab4script.R
@@ -76,8 +76,6 @@ ENV METABOANALYST_VERSION 4.09
 ENV METABOANALYST_LINK https://www.dropbox.com/s/adkps7jq810dyl4/MetaboAnalyst-4.09.war?dl=0
 ENV METABOANALYST_FILE_NAME MetaboAnalyst.war
 
-RUN wget --quiet -O $METABOANALYST_FILE_NAME $METABOANALYST_LINK
-
-COPY $METABOANALYST_FILE_NAME $DEPLOY_DIR
+RUN wget --quiet -O $DEPLOY_DIR/$METABOANALYST_FILE_NAME $METABOANALYST_LINK
 
 ENTRYPOINT ["bin/bash"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ cd ~/Desktop/Metab4_Docker
 $ docker build -t metab_docker .
 
 ### Step 3: Run the Dockerfile, the -ti option will open an interactive Ubuntu terminal into the created container and presents a command prompt
-$ docker run -ti --name METAB_DOCKER -p 8080:8080 metab_docker
+$ docker run -ti --rm --name METAB_DOCKER -p 8080:8080 metab_docker
 
 ## The command prompt will look something like below; you are now in the shell
 root@760b678fd4bf:/# 

--- a/metab4script.R
+++ b/metab4script.R
@@ -1,4 +1,2 @@
 library(Rserve)
-library(pacman)
-p_load(Rserve, RColorBrewer, xtable, som, fitdistrplus, ROCR, RJSONIO, gplots, e1071, caTools, igraph, randomForest, Cairo, pls, pheatmap, lattice, rmarkdown, knitr, data.table, pROC, Rcpp, caret, ellipse, scatterplot3d, impute, pcaMethods, siggenes, globaltest, GlobalAncova, Rgraphviz, KEGGgraph, preprocessCore, genefilter, SSPA, sva, limma, car)
 Rserve(args=" --no-save --RS-conf /etc/rserve.conf")


### PR DESCRIPTION
The following changes are proposed.

1) Fix the war file installation by prefixing the $DEPLOY_DIR path to $METABOANALYST_FILE_NAME on the wget call which eliminates the need for an explicit COPY command.
2) Update docker image from Trusty (14.04) to Xenial (16.04) for better security and add an explicit installation of the required 'sudo' package not present in the Xenial image.
3) Append missing 'xcms' R package to the Bioconductor package list installed by the Dockerfile.
4) Remove the use of p_load() in metab4script.R to avoid needlessly reinstalling the R packages on every execution of the Rscript.
5) Append the '--rm' option to the recommended 'docker run' command so that the container is always automatically removed on exit. Having to manually remove the container can be confusing to new users of docker.