### PR TITLE
Automate the previously needed manual startup steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN install2.r RColorBrewer xtable fitdistrplus som ROCR RJSONIO gplots e1071 ca
 # Install all R packages from Bioconductor 
 RUN R -e 'BiocManager::install(c("impute", "pcaMethods", "siggenes", "globaltest", "GlobalAncova", "Rgraphviz", "KEGGgraph", "preprocessCore", "genefilter", "SSPA", "sva", "limma", "mzID", "xcms"))'
 
-ADD rserve.conf /rserve.conf
+ADD rserve.conf /etc/rserve.conf
 ADD metab4script.R /metab4script.R
 ADD run.sh /run.sh
 RUN chmod +x /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
     littler \
     r-base \
     r-base-dev \
-    r-recommended && \ 
+    r-recommended && \
     ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r && \
     ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r && \
     install.r docopt && \
@@ -75,6 +75,8 @@ RUN R -e 'BiocManager::install(c("impute", "pcaMethods", "siggenes", "globaltest
 
 ADD rserve.conf /rserve.conf
 ADD metab4script.R /metab4script.R
+ADD run.sh /run.sh
+RUN chmod +x /run.sh
 
 # Download and Install Payara Micro
 # From payara/micro github - https://github.com/payara/docker-payaramicro/blob/master/Dockerfile
@@ -106,4 +108,5 @@ ENV METABOANALYST_FILE_NAME MetaboAnalyst.war
 
 RUN wget --quiet -O $DEPLOY_DIR/$METABOANALYST_FILE_NAME $METABOANALYST_LINK
 
-ENTRYPOINT ["bin/bash"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=90.0", "-jar", "/opt/payara/payara-micro.jar"]
+CMD ["/run.sh", "--deploymentDir", "/opt/payara/deployments"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+Rscript /metab4script.R > /dev/null 2>&1


### PR DESCRIPTION
Rather than needing to go into the container shell and executing the R script and Payara application server, the container can now be started with `docker run -d -p 8080:8080 metab_docker` and directly accessed through the webui at http://localhost:8080/MetaboAnalyst/. Remove the `-d` if you would like to see the shell output.